### PR TITLE
fix: possible conn leakage when publisher go routine gets subscription

### DIFF
--- a/elasticache/elasticache.go
+++ b/elasticache/elasticache.go
@@ -730,7 +730,10 @@ func Subscribe[T any](s *Service, channel string, ctx context.Context, handler f
 			case <-ctx.Done():
 				_ = psc.Unsubscribe(channel)
 				return
-			case v := <-pubsubChan:
+			case v, ok := <-pubsubChan:
+				if !ok {
+					return // Channel closed, and release the conn
+				}
 				var data T
 				if err := json.Unmarshal(v.Data, &data); err != nil {
 					fmt.Printf("Failed to unmarshal message: %v\n", err)


### PR DESCRIPTION
I'm also not 100% for sure if this will fully fix our spiking issue / redis connection outage.
But this might be one of the main cause.

Remember to update the go.mod/go.sum after this gets merged. (maybe move v.0.0.0 tag to this commit?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of message channels to prevent blocking or processing invalid data after channel closure, ensuring more reliable message subscription behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->