### PR TITLE
Make sure to unsubscribe redis channel

### DIFF
--- a/elasticache/elasticache.go
+++ b/elasticache/elasticache.go
@@ -725,10 +725,10 @@ func Subscribe[T any](s *Service, channel string, ctx context.Context, handler f
 	// Subscriber
 	go func() {
 		defer conn.Close()
+		defer psc.Unsubscribe(channel)
 		for {
 			select {
 			case <-ctx.Done():
-				_ = psc.Unsubscribe(channel)
 				return
 			case v, ok := <-pubsubChan:
 				if !ok {


### PR DESCRIPTION
https://woodstock-tokyo.atlassian.net/browse/WS-7454


- To handle resource correctly and hopefully solve this error "Redis Pub/Sub error: redigo: unexpected response line (possible server error or unsupported concurrent read by application)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of real-time subscriptions by ensuring channels are always unsubscribed when background tasks exit, reducing risk of lingering subscriptions and unexpected updates.

* **Refactor**
  * Streamlined cleanup logic to run consistently on all exit paths, enhancing stability and reducing potential resource leaks.

* **Chores**
  * Internal maintenance to improve predictability of subscription lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->